### PR TITLE
[android-16] Move AR resource and usecase managers to platform

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -26,9 +26,7 @@ PRODUCT_COPY_FILES := \
 # Audio Configuration
 PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/vendor/etc/microphone_characteristics.xml:$(TARGET_COPY_OUT_VENDOR)/etc/microphone_characteristics.xml \
-    $(DEVICE_PATH)/vendor/etc/mixer_paths_kalama_qrd.xml:$(TARGET_COPY_OUT_VENDOR)/etc/mixer_paths_kalama_qrd.xml \
-    $(DEVICE_PATH)/vendor/etc/resourcemanager_kalama_qrd.xml:$(TARGET_COPY_OUT_VENDOR)/etc/resourcemanager_kalama_qrd.xml \
-    $(DEVICE_PATH)/vendor/etc/usecaseKvManager.xml:$(TARGET_COPY_OUT_VENDOR)/etc/usecaseKvManager.xml
+    $(DEVICE_PATH)/vendor/etc/mixer_paths_kalama_qrd.xml:$(TARGET_COPY_OUT_VENDOR)/etc/mixer_paths_kalama_qrd.xml
 
 # Audio calibration
 PRODUCT_COPY_FILES += \


### PR DESCRIPTION
These Audioreach configurations are common for the
SoC/platform. Move them here from the device repository.